### PR TITLE
Nfc detection using nfc kit

### DIFF
--- a/nfc_app/android/app/build.gradle
+++ b/nfc_app/android/app/build.gradle
@@ -48,8 +48,9 @@ android {
         applicationId "com.example.nfc_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion 19
+        targetSdkVersion 31
+        compileSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/nfc_app/lib/main.dart
+++ b/nfc_app/lib/main.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:nfc_manager/nfc_manager.dart';
+import 'dart:async';
+import 'dart:io' show Platform, sleep;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
 
 void main() => runApp(MyApp());
 
@@ -7,8 +12,8 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'NFC Attendence',
-      home: MyHomePage(title: 'NFC Attendence App'),
+      title: 'NFC Attendance',
+      home: MyHomePage(title: 'NFC Attendance App'),
     );
   }
 }
@@ -22,42 +27,129 @@ class MyHomePage extends StatefulWidget {
   _MyHomePageState createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  String _nfcData = '';
+class _MyHomePageState extends State<MyHomePage>
+    with SingleTickerProviderStateMixin {
+  String _platformVersion = '';
+  NFCAvailability _availability = NFCAvailability.not_supported;
+  NFCTag? _tag;
+  String? _result;
+  late TabController _tabController;
 
-  void _scanNFC() async {
-    NfcManager.instance.startSession(onDiscovered: (NfcTag tag) async {
-      setState(() {
-        _nfcData = tag.data.toString();
-      });
-      NfcManager.instance.stopSession();
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    if (!kIsWeb)
+      _platformVersion =
+          '${Platform.operatingSystem} ${Platform.operatingSystemVersion}';
+    else
+      _platformVersion = 'Web';
+    initPlatformState();
+    _tabController = TabController(length: 1, vsync: this);
+  }
+
+  // Platform messages are asynchronous, so we initialize in an async method.
+  Future<void> initPlatformState() async {
+    NFCAvailability availability;
+    try {
+      availability = await FlutterNfcKit.nfcAvailability;
+    } on PlatformException {
+      availability = NFCAvailability.not_supported;
+    }
+
+    // If the widget was removed from the tree while the asynchronous platform
+    // message was in flight, we want to discard the reply rather than calling
+    // setState to update our non-existent appearance.
+    if (!mounted) return;
+
+    setState(() {
+      _availability = availability;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'NFC Data:',
-            ),
-            Text(
-              '$_nfcData',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('NFC Based Attendance App'),
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _scanNFC,
-        tooltip: 'Scan NFC',
-        child: Icon(Icons.nfc),
+        body: SingleChildScrollView(
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const SizedBox(height: 20),
+                Text('Running on: $_platformVersion\nNFC: $_availability'),
+                const SizedBox(height: 10),
+                ElevatedButton(
+                  onPressed: () async {
+                    try {
+                      NFCTag tag = await FlutterNfcKit.poll();
+                      setState(() {
+                        _tag = tag;
+                      });
+                      await FlutterNfcKit.setIosAlertMessage("Working on it...");
+                      if (tag.standard == "ISO 14443-4 (Type B)") {
+                        String result1 = await FlutterNfcKit.transceive("00B0950000");
+                        String result2 = await FlutterNfcKit.transceive("00A4040009A00000000386980701");
+                        setState(() {
+                          _result = '1: $result1\n2: $result2\n';
+                        });
+                      } else if (tag.type == NFCTagType.iso18092) {
+                        String result1 = await FlutterNfcKit.transceive("060080080100");
+                        setState(() {
+                          _result = '1: $result1\n';
+                        });
+                      } else if (tag.type == NFCTagType.mifare_ultralight ||
+                          tag.type == NFCTagType.mifare_classic ||
+                          tag.type == NFCTagType.iso15693) {
+                        var ndefRecords = await FlutterNfcKit.readNDEFRecords();
+                        var ndefString = '';
+                        for (int i = 0; i < ndefRecords.length; i++) {
+                          ndefString += '${i + 1}: ${ndefRecords[i]}\n';
+                        }
+                        setState(() {
+                          _result = ndefString;
+                        });
+                      } else if (tag.type == NFCTagType.webusb) {
+                        var r = await FlutterNfcKit.transceive("00A4040006D27600012401");
+                        print(r);
+                      }
+                    } catch (e) {
+                      setState(() {
+                        _result = 'error: $e';
+                      });
+                    }
+
+                    // Pretend that we are working
+                    if (!kIsWeb) sleep(Duration(seconds: 1));
+                    await FlutterNfcKit.finish(iosAlertMessage: "Finished!");
+                  },
+                  style: ElevatedButton.styleFrom(
+                    primary: Colors.blue, // Set the background color
+                    onPrimary: Colors.white, // Set the text color
+                  ),
+                  child: Text('Start polling'),
+                ),
+                const SizedBox(height: 10),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: _tag != null
+                      ? Text(
+                          'ID: ${_tag!.id}\nStandard: ${_tag!.standard}\nType: ${_tag!.type}\nATQA: ${_tag!.atqa}\nSAK: ${_tag!.sak}\nHistorical Bytes: ${_tag!.historicalBytes}\nProtocol Info: ${_tag!.protocolInfo}\nApplication Data: ${_tag!.applicationData}\nHigher Layer Response: ${_tag!.hiLayerResponse}\nManufacturer: ${_tag!.manufacturer}\nSystem Code: ${_tag!.systemCode}\nDSF ID: ${_tag!.dsfId}\nNDEF Available: ${_tag!.ndefAvailable}\nNDEF Type: ${_tag!.ndefType}\nNDEF Writable: ${_tag!.ndefWritable}\nNDEF Can Make Read Only: ${_tag!.ndefCanMakeReadOnly}\nNDEF Capacity: ${_tag!.ndefCapacity}\n'
+                        )
+                      : const Text('No tag polled yet.'),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/nfc_app/pubspec.yaml
+++ b/nfc_app/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   nfc_manager: ^3.2.0
   http: ^1.0.0
+  flutter_nfc_kit: ^3.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added dependencies for flutter_nfc_kit package for android and ios support.
Implemented NFC tag polling and transceiving functionality.
Displayed platform information and NFC availability status.
Added a button to initiate NFC polling.
Displayed NFC tag information when a tag is polled.
Modified build.gradle
Updated pubspec.yaml